### PR TITLE
ci: linux build fix

### DIFF
--- a/get-dependencies.sh
+++ b/get-dependencies.sh
@@ -26,6 +26,7 @@ pacman -Syu --noconfirm --needed \
 	libxss              \
 	lld                 \
 	llvm                \
+	rapidjson           \
 	mbedtls2            \
 	mesa                \
 	nasm                \


### PR DESCRIPTION
Make very sure that rapidjson is available for discord-rpc to find when it needs it.