### PR TITLE
add `icu-mini`

### DIFF
--- a/get-dependencies.sh
+++ b/get-dependencies.sh
@@ -56,4 +56,4 @@ pacman -Syu --noconfirm --needed \
 
 wget --retry-connrefused --tries=30 "$EXTRA_PACKAGES" -O ./get-debloated-pkgs.sh
 chmod +x ./get-debloated-pkgs.sh
-./get-debloated-pkgs.sh --add-mesa ffmpeg-mini qt6-base-mini libxml2-mini opus-mini
+./get-debloated-pkgs.sh --add-mesa ffmpeg-mini qt6-base-mini libxml2-mini opus-mini icu-mini


### PR DESCRIPTION
avoids the **30MiB** libicudata nonsense.